### PR TITLE
chore: Push image when PR is closed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    types:
+      - closed
   push:
     branches:
       - main


### PR DESCRIPTION
Expected to push images when PR was merged to `main` but it didn't because I missed this condition.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges-1