### PR TITLE
fix: Include .netrc to be able to pull private repo dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,9 +76,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: Prepare
-      run: |
-        echo "machine github.com login ${{ github.actor }} password ${{ secrets.BUILD_BOT_TOKEN }}" | tee ~/.netrc .netrc
+    - name: Prepare # .netrc is used by docker-build, ~/.netrc is used by go test
+      run: echo "machine github.com login ${{ github.actor }} password ${{ secrets.BUILD_BOT_TOKEN }}" | tee ~/.netrc .netrc
     - name: Push to GitHub Container Registry
       run: make docker-push # defaults to ghcr.io
     - name: Push to DockerHub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: Prepare
-      run: |
-        echo "machine github.com login ${{ github.actor }} password ${{ secrets.BUILD_BOT_TOKEN }}" | tee ~/.netrc .netrc
+    - name: Prepare # .netrc is used by docker-build, ~/.netrc is used by go test
+      run: echo "machine github.com login ${{ github.actor }} password ${{ secrets.BUILD_BOT_TOKEN }}" | tee ~/.netrc .netrc
     - name: Push to GitHub Container Registry
       run: make release # defaults to ghcr.io
     - name: Push to DockerHub


### PR DESCRIPTION
The release job currently fails because it cannot pull down a dependency that exists in a private repo.

https://github.com/weaveworks/pipeline-controller/runs/8013412154?check_suite_focus=true