### PR TITLE
fix: Include pkg folder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN --mount=type=secret,id=netrc,dst=/root/.netrc go mod download
 # Copy the go source
 COPY main.go main.go
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 
 # Build


### PR DESCRIPTION
Missed this from a previous PR. CI didn't build the image upon merge 😞 (although this is being addressed in another PR)