### PR TITLE
Make apiVersion required in `.spec.appRef`

### DIFF
--- a/api/v1alpha1/reference_types.go
+++ b/api/v1alpha1/reference_types.go
@@ -5,11 +5,10 @@ import "fmt"
 // LocalAppReference is used together with a Target to find a single instance of an application on a certain cluster.
 type LocalAppReference struct {
 	// API version of the referent.
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
+	// +required
+	APIVersion string `json:"apiVersion"`
 
 	// Kind of the referent.
-	// +kubebuilder:validation:Enum=HelmRelease
 	// +required
 	Kind string `json:"kind"`
 

--- a/config/crd/bases/pipelines.weave.works_pipelines.yaml
+++ b/config/crd/bases/pipelines.weave.works_pipelines.yaml
@@ -59,13 +59,12 @@ spec:
                     type: string
                   kind:
                     description: Kind of the referent.
-                    enum:
-                    - HelmRelease
                     type: string
                   name:
                     description: Name of the referent.
                     type: string
                 required:
+                - apiVersion
                 - kind
                 - name
                 type: object


### PR DESCRIPTION
The API version cannot be optional as soon as we open up the API to
accept additional kinds being referenced so we can just as well make
it required to begin with and remove the constraint on the possible
`kind` values.
