### PR TITLE
add GH action workflow step to run go mod tidy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,12 @@ jobs:
     - name: Prepare
       run: |
         echo "machine github.com login ${{ github.actor }} password ${{ secrets.BUILD_BOT_TOKEN }}" > ~/.netrc
+    - name: mod tidy
+      uses: evantorrie/mott-the-tider@v1-beta
+      with:
+        gomods: |
+          **/go.mod
+        gomodsum_only: false
     - name: Test
       run: make test
 


### PR DESCRIPTION
The CI workflow should fail if the modules files aren't tidied up.
