### PR TITLE
Fix 'push' build step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+        cache: true
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
     - name: Setup Docker Buildx


### PR DESCRIPTION
We need Go 1.19 but the ubuntu-latest is using Go 1.18 by default.
