### PR TITLE
remove releasing of Helm chart from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release image
 
 on:
   push:
@@ -37,5 +37,3 @@ jobs:
       run: make release # defaults to ghcr.io
     - name: Push to DockerHub
       run: IMG_REGISTRY=docker.io make release
-    - name: Push Helm chart to GitHub Container Registry
-      run: make helm-release


### PR DESCRIPTION
Also renames the workflow to "Release image". We're going to create a
new workflow for releasing a new chart version.
