### PR TITLE
fix the `manifests` Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=pipeline-controller crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	cp ./config/crd/bases/*.yaml ./charts/pipeline-controller/crds/
+	cp ./config/crd/bases/*_*.yaml ./charts/pipeline-controller/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
We only want the actual CRD manifests to end up in the crds/ directory
and exclude e.g. kustomization.yaml. This change esnures that by
changing the pattern in a way that catches the usual CRD naming
pattern.
