### PR TITLE
fix: use a PAT to push to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.BUILD_BOT_TOKEN }}
     - name: Login to DockerHub
       uses: docker/login-action@v2
       with:


### PR DESCRIPTION
This is so that we can trigger a GH workflow as a result of publishing an image.