### PR TITLE
only run update-chart workflow for a tagged image

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -5,7 +5,7 @@ on:
       - published
 jobs:
   update-chart:
-    if: ${{ github.event.registry_package.name == 'pipeline-controller' }}
+    if: ${{ github.event.registry_package.name == 'pipeline-controller' && github.event.registry_package.package_version.container_metadata.tag.name != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: dump event


### PR DESCRIPTION
The `registry_package` event is emitted every time an image is pushed
to the registry which led to the workflow being kicked off 3 times,
for the x86 image, for the ARM image and another time for the
multi-arch image.

By checking for an empty tag name we make sure the workflow only runs
once and only for the event that has the image tag.
