### PR TITLE
fix: Login to ghcr.io before pulling down dependencies

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -73,6 +73,12 @@ jobs:
         uses: mikefarah/yq@v4.30.4
         with:
           cmd: yq -i '.dependencies[2].version = "${{ github.event.registry_package.package_version.container_metadata.tag.name }}"' charts/mccp/Chart.yaml
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - name: Update chart dependencies
         run: cd ./charts/mccp && helm dependency update
       - name: Create Pull Request


### PR DESCRIPTION
Attempt to fix https://github.com/weaveworks/pipeline-controller/actions/runs/3496896895/jobs/5855342476