### PR TITLE
fix: Replace GH action with gpg/git commands

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -15,7 +15,8 @@ jobs:
           gpg --list-secret-keys --keyid-format=long
           echo -n "$GPG_SIGNING_KEY" | gpg --import
           gpg --list-secret-keys --keyid-format=long
-          git config user.signingkey 4152F5C0824BCDE3
+          key_id = $(echo -n "$GPG_SIGNING_KEY" | gpg --dry-run --import --verbose 2>&1 | awk '/^gpg: sec/ { print $3 }' | cut -d '/' -f 2)
+          git config user.signingkey "${key_id}"
           git config commit.gpgsign true
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
This PR replaces a GH action and uses gpg/git commands instead to setup signing commits.

As per https://github.com/weaveworks/pipeline-controller/pull/102#discussion_r1026382768 I have added a new PGP key to use for signing that does not require a passphrase.

Closes #113 