### PR TITLE
fix: Remove redundant commands

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -12,11 +12,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Import GPG key for signing commits
         run: |
-          gpg --list-secret-keys --keyid-format=long
           echo -n "$GPG_SIGNING_KEY" | gpg --import
-          gpg --list-secret-keys --keyid-format=long
           key_id=$(echo -n "$GPG_SIGNING_KEY" | gpg --dry-run --import --verbose 2>&1 | awk '/^gpg: sec/ { print $3 }' | cut -d '/' -f 2)
-          git config user.signingkey $key_id
+          git config user.signingkey "${key_id}"
           git config commit.gpgsign true
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
Tidying up CI by removing redundant commands, used for troubleshooting.