### PR TITLE
fix: Log error and return info message

### DIFF
--- a/server/promotion_handler.go
+++ b/server/promotion_handler.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"html/template"
 	"io"
 	"net/http"
 	"regexp"
@@ -103,8 +104,9 @@ func (h DefaultPromotionHandler) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 
 	promEnv, err := lookupNextEnvironment(pipeline, env, ev.InvolvedObject)
 	if err != nil {
+		h.log.Error(err, "error looking up next environment")
 		rw.WriteHeader(http.StatusUnprocessableEntity)
-		fmt.Fprint(rw, err.Error())
+		fmt.Fprint(rw, template.HTMLEscapeString(err.Error()))
 		return
 	}
 	promotion.Environment = *promEnv
@@ -167,7 +169,7 @@ func lookupNextEnvironment(pipeline pipelinev1alpha1.Pipeline, env string, appRe
 		pipeline.Spec.AppRef.Kind != appRef.Kind ||
 		pipeline.Spec.AppRef.Name != appRef.Name ||
 		!namespaceInTargets(sourceEnv.Targets, appRef.Namespace) {
-		return nil, fmt.Errorf("involved object doesn't match Pipeline definition")
+		return nil, fmt.Errorf("involved object does not match Pipeline definition")
 	}
 	return promEnv, nil
 }

--- a/server/promotion_handler_test.go
+++ b/server/promotion_handler_test.go
@@ -276,7 +276,7 @@ func TestInvolvedObjectDoesntMatch(t *testing.T) {
 			tt.transform(&ev)
 			resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, ev))
 			g.Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
-			g.Expect(resp.Body.String()).To(Equal("involved object doesn't match Pipeline definition"))
+			g.Expect(resp.Body.String()).To(Equal("involved object does not match Pipeline definition"))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #130 

In the HTTP response of a promotion, we return an error object that wasn't being sanitised. This PR uses [HTMLEscapeString](https://pkg.go.dev/html/template#HTMLEscapeString) to sanitise it.

I considered adding a test for this but it would require passing a function instead of `lookupNextEnvironment` and the code may look a bit weird. 

If there are other alternatives, let's discuss.