### PR TITLE
feat: add retries to the promotion webhook

### DIFF
--- a/pkg/retry/exponential.go
+++ b/pkg/retry/exponential.go
@@ -1,0 +1,72 @@
+package retry
+
+import (
+	"math"
+	"time"
+)
+
+type RetryError struct {
+	message string
+}
+
+func (e RetryError) Error() string {
+	return e.message
+}
+
+type RetryFn func() error
+type ErrorHandlerFn func(error) bool
+
+type ExponentialOptions struct {
+	retries          int
+	delayBaseSeconds float64
+	maxDelaySeconds  float64
+	fn               RetryFn
+	errorHandlerFn   ErrorHandlerFn
+}
+
+func Exponential(withOpts ...ExponentialWith) error {
+	opts := ExponentialOptions{
+		retries:          3,
+		delayBaseSeconds: 2,
+		maxDelaySeconds:  30,
+	}
+
+	for _, fn := range withOpts {
+		fn(&opts)
+	}
+
+	if opts.fn == nil {
+		return RetryError{message: "fn is not defined, nothing to retry"}
+	}
+
+	var (
+		err error
+		try int = 0
+	)
+
+	for {
+		try++
+
+		wait := math.Pow(opts.delayBaseSeconds, float64(try))
+		if wait > opts.maxDelaySeconds {
+			wait = opts.maxDelaySeconds
+		}
+
+		err = opts.fn()
+		if err == nil {
+			return nil
+		}
+
+		if opts.errorHandlerFn != nil && opts.errorHandlerFn(err) {
+			return nil
+		}
+
+		if try >= opts.retries {
+			break
+		}
+
+		time.Sleep(time.Second * time.Duration(wait))
+	}
+
+	return err
+}

--- a/pkg/retry/exponential_opts.go
+++ b/pkg/retry/exponential_opts.go
@@ -1,0 +1,33 @@
+package retry
+
+type ExponentialWith func(opt *ExponentialOptions)
+
+func WithRetries(retries int) ExponentialWith {
+	return func(opt *ExponentialOptions) {
+		opt.retries = retries
+	}
+}
+
+func WithDelayBase(delaySeconds float64) ExponentialWith {
+	return func(opt *ExponentialOptions) {
+		opt.delayBaseSeconds = delaySeconds
+	}
+}
+
+func WithMaxDelay(maxSeconds float64) ExponentialWith {
+	return func(opt *ExponentialOptions) {
+		opt.maxDelaySeconds = maxSeconds
+	}
+}
+
+func WithErrorHandler(errorHandlerFn ErrorHandlerFn) ExponentialWith {
+	return func(opt *ExponentialOptions) {
+		opt.errorHandlerFn = errorHandlerFn
+	}
+}
+
+func WithFn(fn RetryFn) ExponentialWith {
+	return func(opt *ExponentialOptions) {
+		opt.fn = fn
+	}
+}

--- a/pkg/retry/exponential_test.go
+++ b/pkg/retry/exponential_test.go
@@ -1,0 +1,100 @@
+package retry_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/weaveworks/pipeline-controller/pkg/retry"
+)
+
+func TestExponential(t *testing.T) {
+	tests := []struct {
+		name              string
+		opts              []retry.ExponentialWith
+		wantErr           bool
+		numberOfErrCalled int
+		minTime           float64
+		maxTime           float64
+	}{
+		{
+			name:              "with defaults",
+			opts:              []retry.ExponentialWith{},
+			wantErr:           true,
+			numberOfErrCalled: 0,
+			minTime:           0,
+			maxTime:           1.1,
+		},
+		{
+			name: "with fn",
+			opts: []retry.ExponentialWith{
+				retry.WithFn(func() error {
+					return fmt.Errorf("some error")
+				}),
+				retry.WithDelayBase(1.1),
+				retry.WithMaxDelay(2),
+			},
+			wantErr:           true,
+			numberOfErrCalled: 3,
+			minTime:           2,
+			maxTime:           3.1,
+		},
+		{
+			name: "with error handler",
+			opts: []retry.ExponentialWith{
+				retry.WithFn(func() error {
+					return fmt.Errorf("some error")
+				}),
+				retry.WithErrorHandler(func(e error) bool {
+					return false
+				}),
+				retry.WithRetries(2),
+				retry.WithMaxDelay(4),
+			},
+			wantErr:           true,
+			numberOfErrCalled: 0,
+			minTime:           2,
+			maxTime:           3.1,
+		},
+		{
+			name: "no retry",
+			opts: []retry.ExponentialWith{
+				retry.WithFn(func() error {
+					return fmt.Errorf("some error")
+				}),
+				retry.WithDelayBase(1),
+				retry.WithRetries(0),
+			},
+			wantErr:           true,
+			numberOfErrCalled: 1,
+			minTime:           0,
+			maxTime:           3.1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errCalled := 0
+			errFn := func(_ error) bool {
+				errCalled++
+				return false
+			}
+			start := time.Now()
+			// Make sure it's called first and allow test case to override this.
+			opts := []retry.ExponentialWith{retry.WithErrorHandler(errFn)}
+			opts = append(opts, tt.opts...)
+			if err := retry.Exponential(opts...); (err != nil) != tt.wantErr {
+				t.Errorf("Exponential() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			execTime := time.Since(start)
+			if tt.minTime != 0 && float64(execTime) < tt.minTime*float64(time.Second) {
+				t.Errorf("Exponential() expected to run longer then %.2fs, done in %.2fs", tt.minTime, execTime.Seconds())
+			}
+			if tt.maxTime != 0 && float64(execTime) > tt.maxTime*float64(time.Second) {
+				t.Errorf("Exponential() expected to be done under %.2fs, done in %.2fs", tt.maxTime, execTime.Seconds())
+			}
+			if errCalled != tt.numberOfErrCalled {
+				t.Errorf("Error handler of Exponential() expected to be called %d times, it was called %d times", tt.numberOfErrCalled, errCalled)
+			}
+		})
+	}
+}

--- a/server/opts.go
+++ b/server/opts.go
@@ -42,3 +42,13 @@ func StrategyRegistry(stratReg strategy.StrategyRegistry) Opt {
 		return nil
 	}
 }
+
+func WithRetry(delay, maxDelay, threshold int) Opt {
+	return func(s *PromotionServer) error {
+		s.retry.Delay = delay
+		s.retry.MaxDelay = maxDelay
+		s.retry.Threshold = threshold
+
+		return nil
+	}
+}

--- a/server/promotion_handler_test.go
+++ b/server/promotion_handler_test.go
@@ -158,6 +158,14 @@ func createHmacSecret(g *WithT, t *testing.T, p v1alpha1.Pipeline) corev1.Secret
 	return secret
 }
 
+func testRetryOpts() server.RetryOpts {
+	return server.RetryOpts{
+		Delay:     1,
+		MaxDelay:  1,
+		Threshold: 1,
+	}
+}
+
 func TestGet(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
 	h := server.DefaultPromotionHandler{}
@@ -167,14 +175,14 @@ func TestGet(t *testing.T) {
 
 func TestPostWithWrongPath(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{}), nil, nil)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{}), nil, nil, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/", nil, nil)
 	g.Expect(resp.Code).To(Equal(http.StatusNotFound))
 }
 
 func TestPostWithNoBody(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{}), nil, k8sClient, testRetryOpts())
 	createTestPipeline(g, t)
 	resp := requestTo(g, h, http.MethodPost, "/default/app/env", nil, nil)
 	g.Expect(resp.Code).To(Equal(http.StatusBadRequest))
@@ -182,7 +190,7 @@ func TestPostWithNoBody(t *testing.T) {
 
 func TestPostWithIncompatibleBody(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{}), nil, k8sClient, testRetryOpts())
 	createTestPipeline(g, t)
 	resp := requestTo(g, h, http.MethodPost, "/default/app/env", nil, []byte("incompatible"))
 	g.Expect(resp.Code).To(Equal(http.StatusBadRequest))
@@ -190,7 +198,7 @@ func TestPostWithIncompatibleBody(t *testing.T) {
 
 func TestPostWithUnknownPipeline(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/ns/app/env", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusNotFound))
 }
@@ -216,11 +224,11 @@ func TestVerifyXSignature(t *testing.T) {
 			location: "success",
 		}
 		stratReg := strategy.StrategyRegistry{&strat}
-		h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient)
+		h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient, testRetryOpts())
 		return requestTo(g, h, http.MethodPost, "/default/app/dev", header, eventData)
 	}
 
-	t.Run("succeeds with proper hmac", func(t *testing.T) {
+	t.Run("succeeds with proper hmac", func(_ *testing.T) {
 		mac := hmac.New(sha256.New, secret.Data["hmac-key"])
 		_, err := mac.Write(eventData)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -230,7 +238,7 @@ func TestVerifyXSignature(t *testing.T) {
 		g.Expect(resp.Code).To(Equal(http.StatusCreated))
 	})
 
-	t.Run("fails with invalid hmac", func(t *testing.T) {
+	t.Run("fails with invalid hmac", func(_ *testing.T) {
 		resp := makeSignedReq("invalid")
 		g.Expect(resp.Code).To(Equal(http.StatusUnauthorized))
 	})
@@ -271,7 +279,7 @@ func TestInvolvedObjectDoesntMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient)
+			h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient, testRetryOpts())
 			ev := createEvent()
 			tt.transform(&ev)
 			resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, ev))
@@ -284,7 +292,7 @@ func TestInvolvedObjectDoesntMatch(t *testing.T) {
 func TestPromotionBeyondLastEnv(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
 	createTestPipeline(g, t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/no-targets", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
 	g.Expect(resp.Body.String()).To(Equal("cannot promote beyond last environment no-targets"))
@@ -293,7 +301,7 @@ func TestPromotionBeyondLastEnv(t *testing.T) {
 func TestPromotionToEnvWithoutTarget(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
 	createTestPipeline(g, t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/prod", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
 	g.Expect(resp.Body.String()).To(Equal("environment no-targets has no targets"))
@@ -302,7 +310,7 @@ func TestPromotionToEnvWithoutTarget(t *testing.T) {
 func TestPromotionFromUnknownEnv(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
 	createTestPipeline(g, t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/foo", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusUnprocessableEntity))
 	g.Expect(resp.Body.String()).To(Equal("app default/app has no environment foo defined"))
@@ -311,7 +319,7 @@ func TestPromotionFromUnknownEnv(t *testing.T) {
 func TestPromotionWithNoMetadataInEvent(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
 	createTestPipeline(g, t)
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), nil, k8sClient, testRetryOpts())
 	ev := createEvent()
 	ev.Metadata = nil
 	resp := requestTo(g, h, http.MethodPost, "/default/app/foo", nil, marshalEvent(g, ev))
@@ -327,7 +335,7 @@ func TestPromotionStarted(t *testing.T) {
 		location: "success",
 	}
 	stratReg := strategy.StrategyRegistry{&strat}
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusCreated))
 	g.Expect(resp.Body.String()).To(Equal(""))
@@ -355,7 +363,7 @@ func TestPromotionFails(t *testing.T) {
 		err: fmt.Errorf("this didn't work"),
 	}
 	stratReg := strategy.StrategyRegistry{&strat}
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusInternalServerError))
 	g.Expect(resp.Body.String()).To(Equal("error promoting application, please consult the promotion server's logs"))
@@ -380,7 +388,7 @@ func TestPromotionWithoutLocation(t *testing.T) {
 	createTestPipelineWithPromotion(g, t)
 	strat := introspectableStrategy{}
 	stratReg := strategy.StrategyRegistry{&strat}
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusNoContent))
 	g.Expect(resp.Body.String()).To(Equal(""))
@@ -406,7 +414,7 @@ func TestPromotionWithoutPromotionSpec(t *testing.T) {
 	createTestPipeline(g, t)
 	strat := introspectableStrategy{}
 	stratReg := strategy.StrategyRegistry{&strat}
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusInternalServerError))
 	g.Expect(resp.Body.String()).To(Equal("error promoting application, please consult the promotion server's logs"))
@@ -418,7 +426,7 @@ func TestPromotionWithoutUnknownStrategy(t *testing.T) {
 	g := testingutils.NewGomegaWithT(t)
 	createTestPipelineWithPromotion(g, t)
 	stratReg := strategy.StrategyRegistry{}
-	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient)
+	h := server.NewDefaultPromotionHandler(logger.NewLogger(logger.Options{LogLevel: "trace"}), stratReg, k8sClient, testRetryOpts())
 	resp := requestTo(g, h, http.MethodPost, "/default/app/dev", nil, marshalEvent(g, createEvent()))
 	g.Expect(resp.Code).To(Equal(http.StatusInternalServerError))
 	g.Expect(resp.Body.String()).To(Equal("error promoting application, please consult the promotion server's logs"))

--- a/server/promotion_server.go
+++ b/server/promotion_server.go
@@ -24,6 +24,9 @@ import (
 const (
 	DefaultRateLimitCount    = 20
 	DefaultRateLimitInterval = 30
+	DefaultRetryDelay        = 2
+	DefaultRetryMaxDelay     = 20
+	DefaultRetryThreshold    = 3
 )
 
 type PromotionServer struct {
@@ -35,11 +38,18 @@ type PromotionServer struct {
 	promEndpointName string
 	stratReg         strategy.StrategyRegistry
 	rateLimit        rateLimit
+	retry            RetryOpts
 }
 
 type rateLimit struct {
 	count    int
 	interval time.Duration
+}
+
+type RetryOpts struct {
+	Delay     int
+	MaxDelay  int
+	Threshold int
 }
 
 type Opt func(s *PromotionServer) error
@@ -102,6 +112,7 @@ func setDefaults(s *PromotionServer) {
 			s.log.WithName("handler"),
 			s.stratReg,
 			s.c,
+			s.retry,
 		)
 	}
 	if s.promEndpointName == "" {


### PR DESCRIPTION
The `retry` package has one algorithm now (exponential), but it can be
extended to have more options (like constant delay).

The the server has three new `retry` related CLI flags:
* `--promotion-retry-delay`: Delay between promotion retries in seconds. (default 3)
* `--promotion-retry-max-delay`: Maximum delay between promotion retries. (default 20)
* `--promotion-retry-threshold`: How many times a promotion should be retried. (default 3)

Closes #58

Why didn't I use an existing library for retries
------------------------------------------------

The main reason is, retry libraries are built around the concept of
retrying on client side for example http requests. Exponential retry
logic is good and I think that's the most reasonable one to use (for now
at least), but exponential can grow... well exponentially, but we may
want to limit that value, so the first `N` tries follow the exponential
delay, but we can be sure we don't have 2 minutes long delay between
retries, but we still want to retry `N+M` times, and we want to wait
maximum X seconds between retries after `N` tries
(for example: 2, 4, 8, 16, 20, 20, 20).

For example I tried avast/retry-go but it was a mess with `DelayType` to
implement the logic described above.

References:
* https://github.com/weaveworks/pipeline-controller/issues/58
* https://github.com/avast/retry-go
