### PR TITLE
fix: Replace fmt.Fprint with template.HTMLEscape

### DIFF
--- a/server/promotion_handler.go
+++ b/server/promotion_handler.go
@@ -106,7 +106,7 @@ func (h DefaultPromotionHandler) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 	if err != nil {
 		h.log.Error(err, "error looking up next environment")
 		rw.WriteHeader(http.StatusUnprocessableEntity)
-		fmt.Fprint(rw, template.HTMLEscapeString(err.Error()))
+		template.HTMLEscape(rw, []byte(err.Error()))
 		return
 	}
 	promotion.Environment = *promEnv


### PR DESCRIPTION
Attempt to fix #130 again.