### PR TITLE
fix: update update-chart github action to be idenependent from dependency order

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Update pipeline-controller chart version
         uses: mikefarah/yq@v4.30.4
         with:
-          cmd: yq -i '.dependencies[3].version = "${{ github.event.registry_package.package_version.container_metadata.tag.name }}"' charts/mccp/Chart.yaml
+          cmd: yq -i '(.dependencies[] | select(.name=="pipeline-controller") | .version) |= "${{ github.event.registry_package.package_version.container_metadata.tag.name }}"' charts/mccp/Chart.yaml
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION

```
weave-gitops-enterprise on  main via  v1.19.4 on   (eu-central-1)
❯ yq -i '(.dependencies[] | select(.name=="pipeline-controller") | .version) |= "nice"' charts/mccp/Chart.yaml

weave-gitops-enterprise on  main [!] via  v1.19.4 on   (eu-central-1)
❯ git diff
diff --git a/charts/mccp/Chart.yaml b/charts/mccp/Chart.yaml
index 4862e19f..da278ff8 100644
--- a/charts/mccp/Chart.yaml
+++ b/charts/mccp/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     repository: "https://weaveworks.github.io/policy-agent"
     condition: policy-agent.enabled
   - name: pipeline-controller
-    version: "0.14.0"
+    version: "nice"
     repository: "oci://ghcr.io/weaveworks/charts"
     condition: enablePipelines
   - name: gitopssets-controller
```

Why `|=` and not `=`?
=====================

The `|=` is an update/modification assignment while `=` is plain assignment. In this case they behave the same, but in general I tend to use `|=` as it's more flexible.

> Most users will want to use modification assignment operators, such as
> |= or +=, rather than =.
>
> Source: https://stedolan.github.io/jq/manual/#Assignment

Closes #153

References:
* https://stedolan.github.io/jq/manual/#Assignment
* https://stedolan.github.io/jq/manual/#select(boolean_expression)
* https://github.com/weaveworks/pipeline-controller/issues/153