### PR TITLE
chore(ci): do not run test and e2e test when there are no code changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
     paths-ignore:
-      - "charts/**" # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      - "charts/**"
+      - "docs/**"
+      - "hack/**"
+      - "*.md"
   pull_request_target:
     types:
       - closed

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,11 @@ name: e2e
 
 on:
   pull_request:
+    paths-ignore:
+      # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+      - "docs/**"
+      - "hack/**"
+      - "*.md"
   push:
     branches:
       - main


### PR DESCRIPTION
The test and e2e test workflows can run for 20-30 minutes and they use a lot of resources. If a commit/pull request contains only docs changes, it's a waste of time and resources.

`charts/**` can be ignored for tests, but not for e2e tests because that workflow uses helm charts.

Closes #688

References:
* https://github.com/weaveworks/tf-controller/issues/688