### PR TITLE
Check if `make test` modifies go mod files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,8 @@ jobs:
         echo "machine github.com login ${{ github.actor }} password ${{ secrets.BUILD_BOT_TOKEN }}" > ~/.netrc
     - name: Test
       run: make test
+    - name: Check no mod updates
+      run: git diff --exit-code go.mod go.sum go.work.sum
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's easy to accidentally leave out changes to go mod files (go.mod, go.sum, go.work.sum) when preparing PRs, especially if you rebase. Usually, any go operation would catch it, because the default is `-mod readonly`; but, workspace files seem exempt from this, and `go vet` doesn't appear to honour it either.

Therefore: add a backstop in the GitHub Actions workflow, to stop incidental changes slipping through.