### PR TITLE
Avoid some duplication in CI run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 .PHONY: all
-all: build
+all: lint test build
 
 ##@ General
 
@@ -116,7 +116,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go --log-level debug
 
 .PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker buildx build --secret id=netrc,src=.netrc -t ${IMG} $(DOCKER_BUILD_ARGS) $(DOCKER_BUILD_LABELS) .
 
 .PHONY: docker-push


### PR DESCRIPTION
The CI workflow runs both `make test` and `make docker-build`, and the latter target already has `test` as a prerequisite. I'd rather be explicit about what's run in workflows, so: remove `test` as a prerequisite of `docker-build`. (It's not a prerequisite of `build`, for the record.)

While I'm here, let's make the default target something useful: now it runs `lint`, `test`, and `build`.