### PR TITLE
Make sure cache key is readable in log

### DIFF
--- a/controllers/leveltriggered/caching.go
+++ b/controllers/leveltriggered/caching.go
@@ -360,7 +360,7 @@ func newGC(caches cachesInterface, logger logr.Logger) *gc {
 }
 
 func (gc *gc) register(key clusterAndGVK) {
-	gc.log.Info("cache key registered for GC", "key", key)
+	gc.log.Info("cache key registered for GC", "key", key.String())
 	gc.queue.Add(key) // NB not rate limited. Though, this is called when the key is introduced, so it shouldn't matter one way or the other.
 }
 


### PR DESCRIPTION
When a `clusterAndGVK` value is supplied as a field in the log, the GroupVersionKind part of the struct isn't included in the output. There's no especial reason to prefer a struct value, so this commit stringifies it.